### PR TITLE
I2C fix for WT32_SC01 and disable IR_SENSOR

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -117,8 +117,8 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 lib_deps =
-	 ${common_env_data.lib_deps_ext}
-	 bodmer/TFT_eSPI@^2.3.81
+	${common_env_data.lib_deps_ext}
+	bodmer/TFT_eSPI@^2.3.81
 
 build_flags =
 	-DTARGET_WT32_SC01
@@ -163,12 +163,11 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 lib_deps =
-	 ${common_env_data.lib_deps_ext}
+	${common_env_data.lib_deps_ext}
 	lovyan03/LovyanGFX@>=0.4.10
 
 build_flags =
 	-DTARGET_WT32_SC01
-	-DNO_MPU6050
 	-DNO_VL53L0X
 	-DLGFX_WT32_SC01
 	-DLGFX_USE_V1


### PR DESCRIPTION
On WT32_SC01 the defult I2C pin 21,22 is used as
for the display together with the IR_SENSOR
pins 13,15.

This change will use I2C on 18,19 pins for WT32_SC01
 and disable the IR_SENSOR Interrup setup as
 all setups now seem to use REED sensor anyway.