### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/platformio-ci.yml
+++ b/.github/workflows/platformio-ci.yml
@@ -6,6 +6,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/lefty01/ESP32_TTGO_FTMS/security/code-scanning/2](https://github.com/lefty01/ESP32_TTGO_FTMS/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block that scopes the GITHUB_TOKEN to the minimum required rights. For this workflow, only read access to the repository contents is needed, since it performs a checkout and local build but does not write to the repo, create issues, or modify pull requests.

The best minimally invasive change is to add a single `permissions` block at the workflow root (top level, alongside `on:` and `jobs:`) specifying `contents: read`. This will apply to all jobs that do not have their own `permissions` block, which includes the `build` job. No functional behavior of the build steps changes; only the token’s capabilities are reduced. Concretely, in `.github/workflows/platformio-ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (after line 7, before line 10 in the provided snippet). No imports, methods, or other definitions are needed since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
