### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -12,6 +12,9 @@ jobs:
   formatting-check:
     name: Formatting Check (${{ matrix.path }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/lefty01/ESP32_TTGO_FTMS/security/code-scanning/1](https://github.com/lefty01/ESP32_TTGO_FTMS/security/code-scanning/1)

In general, to fix this issue you should add an explicit `permissions` block either at the workflow root (applies to all jobs) or inside the specific job that uses the `GITHUB_TOKEN`. This block should grant only the minimal scopes needed for the workflow to function.

For this workflow, the job needs to: (1) read repository contents (for `actions/checkout` and `git ls-files`), and (2) write comments to pull requests via `marocchino/sticky-pull-request-comment`. It doesn’t need to push commits, manage issues, or modify other resources. The best minimal permissions set is therefore: `contents: read` and `pull-requests: write`. To implement this without changing functionality, add a `permissions` mapping under the `formatting-check` job (same indentation level as `runs-on`, `strategy`, and `steps`). No additional imports or external methods are needed because this is a YAML configuration change only. The rest of the workflow remains unchanged.

Concretely, in `.github/workflows/clang-format-check.yml`, insert:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

between `runs-on: ubuntu-latest` and `strategy:` for the `formatting-check` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
